### PR TITLE
Update tsconfig to understand node module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,13 @@
 {
     "compilerOptions": {
         "module": "amd",
-        "sourceMap": false
+        "sourceMap": false,
+        "moduleResolution": "node",
+        "types": [
+            "vss-web-extension-sdk",
+            "jquery",
+            "q"
+        ]
     },
     "exclude": [
         "node_modules"


### PR DESCRIPTION
In your readme you mentioned the issue with the typings.  With this updated tsconfig, the typings work as expected.